### PR TITLE
Zscore fix

### DIFF
--- a/cgnet/feature/statistics.py
+++ b/cgnet/feature/statistics.py
@@ -150,8 +150,8 @@ class ProteinBackboneStatistics():
         zscore_array = np.vstack([
             np.concatenate([self.stats_dict[key][stat]
                             for key in order]) for stat in ['mean', 'std']])
-        if not tensor:
-            zscore_array = torch.from_numpy(zscore_array)
+        if tensor:
+            zscore_array = torch.from_numpy(zscore_array).float()
 
         if as_dict:
             zscore_dict = {}


### PR DESCRIPTION
I think I found a bug in the zscore logic while running tests on my local machine. Previously, if `tensor=True` and `as_dict=False` were specified in the `get_zscores()` method arguments, the method would return a `numpy.array()` of the means and standard deviations. I also added a call to `torch.tensor.float()` to making the returned tensor of type `FloatTensor`.