### PR TITLE
Sim fix

### DIFF
--- a/cgnet/network/utils.py
+++ b/cgnet/network/utils.py
@@ -239,8 +239,8 @@ class Simulation():
             noise = self.rng.randn(self.n_sims,
                                    self.n_beads,
                                    self.n_dims)
-            x_new = x_old.detach().numpy() + forces*dtau + \
-                    np.sqrt(2*dtau/self.beta)*noise
+            x_new = (x_old.detach().numpy() + forces*dtau +
+                     np.sqrt(2*dtau/self.beta)*noise)
             if t % self.save_interval == 0:
                 self.simulated_traj[t//self.save_interval, :, :] = x_new
                 if self.save_forces:


### PR DESCRIPTION
 Development:
 - [x] Implement feature / fix bug
 - [ ] Add documentation
 - [ ] Add tests
 
 Checks:
 - [ x ] Run `nosetests`
 - [ x ] Check pep8 compliance

Hey all. I have made a small change to the `simulate` method in the `Simulation` class in `utils.py`. Essentially, the Langevin update is now carried out by in numpy operations as opposed to torch operations. I am still searching through the torch docs/forums, but I think there might be some funny business when it comes to copy/assignment and the fact that input coordinates to CGnet need `requires_grad=True` when casting as tensors. Now, the simulations seem to be faster and each saving step should take the same amount of time. Try it out in the notebook to see if you can get a satisfactory result, and I will be happy to discuss any changes.
