### PR TITLE
Fixed example notebook layers from four to five

### DIFF
--- a/examples/Training-A-Coarse-Grained-Force-Field.ipynb
+++ b/examples/Training-A-Coarse-Grained-Force-Field.ipynb
@@ -196,7 +196,7 @@
     "Now we are ready to start designing the architecture of our CGnet. We follow the optimal architecture in the CGnet paper [1], which consists of:\n",
     "\n",
     "- a feature layer that outputs pairwise distances, angles, and dihedral angles from the Cartesian input trajectory that subtracts the means and divides by the standard deviations,\n",
-    "- 4 hidden linear layers (bias term inclusive) with 160 nodes each, with the first three followed by `Tanh()` activation, and\n",
+    "- 5 hidden linear layers (bias term inclusive) with 160 nodes each, with the first three followed by `Tanh()` activation, and\n",
     "- harmonic prior layers that compute prior energies from bonds and angles.\n",
     "\n",
     "The layers are stored in the list `layers` and the priors are stored in the list `priors`.\n",
@@ -218,7 +218,7 @@
     "layers += LinearLayer(num_feat, 160, activation=nn.Tanh())\n",
     "\n",
     "# The inner hidden layers stay the same size\n",
-    "for _ in range(3):\n",
+    "for _ in range(4):\n",
     "    layers += LinearLayer(160, 160, activation=nn.Tanh())\n",
     "\n",
     "# The last layer produces a single value\n",
@@ -636,7 +636,7 @@
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
-   "name": "Python 3"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -648,7 +648,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.7.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
 Development:
 - [x] Implement feature / fix bug
 - [ ] Add documentation
 - [ ] Add tests
 
 Checks:
 - [x] Run `nosetests`
 - [x] Check pep8 compliance

Hey guys. I realized I made a mistake in the example notebook: the optimal depth of the network for alanine dipeptide is 5 layers, not 4. See Attached figure 5.a from:

Wang, J., Olsson, S., Wehmeyer, C., Pérez, A., Charron, N. E., de Fabritiis, G., … Clementi, C. (2019). Machine Learning of Coarse-Grained Molecular Dynamics Force Fields. ACS Central Science. https://doi.org/10.1021/acscentsci.8b00913
![ala_cv](https://user-images.githubusercontent.com/42926839/60998858-69737a00-a31f-11e9-9d6b-59617eb1fc57.png)
