### PR TITLE
Compute index mapping from non-redundant to redundant distance representations

### DIFF
--- a/cgnet/feature/statistics.py
+++ b/cgnet/feature/statistics.py
@@ -343,7 +343,7 @@ class ProteinBackboneStatistics():
         """
         mapping = np.zeros((self.n_beads, self.n_beads - 1), dtype='uint8')
         for bead in range(self.n_beads):
-            def seq1 (bead, n_beads):
+            def seq1(bead, n_beads):
                 n = bead
                 j = n_beads - 1
                 while(True):
@@ -351,12 +351,13 @@ class ProteinBackboneStatistics():
                     n = n + j
                     j -= 1
             max_calls = self.n_beads - bead - 1
-            gen = seq1(bead,self.n_beads)
+            gen = seq1(bead, self.n_beads)
             idx = np.array([bead] + [next(gen) for _ in range(max_calls-1)])
             mapping[bead, (bead):] = idx
             if bead < self.n_beads - 1:
                 mapping[(bead+1):, bead] = idx
         self.redundant_distance_mapping = mapping
+
 
 def kl_divergence(dist_1, dist_2):
     r"""Compute the Kullback-Leibler (KL) divergence between two discrete

--- a/cgnet/tests/test_protein_statistics.py
+++ b/cgnet/tests/test_protein_statistics.py
@@ -120,5 +120,5 @@ def test_form_redundant_distances():
     assert index_mapping.shape == (beads, beads - 1)
     # mock distance data
     dist = np.random.randn(frames, int((beads - 1) * (beads) / 2))
-    redundant_dist =  dist[:, index_mapping]
+    redundant_dist = dist[:, index_mapping]
     assert redundant_dist.shape == (frames, beads, beads - 1)


### PR DESCRIPTION
 Development:
 - [x] Implement feature / fix bug
 - [x] Add documentation
 - [x] Add tests
 
 Checks:
 - [x] Run `nosetests`
 - [x] Check pep8 compliance

Hey guys. Certain schnet tools, such as `RadialBasisFunction`, require pairwise distances in neighbor-matrix form for each time step - that is the input data shape to their `forward` methods is
`[n_examples, n_beads, n_beads - 1]`. However, the output shape of the subset of pairwise distances from `ProteinBackboneFeature` is `[n_examples, n_distances]`, and their order is determined in the same fashion as `mdtraj` tools. Not wanting to compute distances twice, I have added a method, `form_redundant_distances()`, to `ProteinBackboneStatistics` to compute the matrix index mapping from the cgnet-style non-redundant distance representation to schnet-style redundant distance representation. This mapping is a pseudo-symmetrix matrix whose elements are determined from shifted sequences similar to [triangular numbers](https://en.wikipedia.org/wiki/Triangular_number) . In practice, the method is used in the following way:

```
stats.form_redundant_distances()
mapping = stats.redundant_distance_mapping
redundant_dist = nonredundant_dist[:, mapping]
```

As a speed, test, I clocked the calculation of this mapping matrix from distances on a C-alpha model of Titin (~30k residues, matrix size ~9 x 10^8) and it took 131 seconds. Given that we are nowhere near that with our model sizes, and given that this matrix only needs to be calculated once, I think that scalability is okay. If you guys can think of any ways to speed up this calculation, or any improvements to be made, let me know.

Once this and #54 are reviewed, I will push the code for the schnet incorporation into our existing code (all of Dominik's tools minus the embedding layer).
