### PR TITLE
suggestions for get-idx

### DIFF
--- a/cgnet/feature/statistics.py
+++ b/cgnet/feature/statistics.py
@@ -82,7 +82,7 @@ class ProteinBackboneStatistics():
             self._get_stats(self.distances, 'Distances')
             self.order += ['Distances']
             if get_redundant_distance_mapping:
-                self._form_redundant_distances()
+                self._get_redundant_distance_mapping()
 
         if get_angles:
             self._get_angles()
@@ -374,7 +374,7 @@ class ProteinBackboneStatistics():
         indices = [idx + start_idx for idx in indices]
         return indices
 
-    def _form_redundant_distances(self):
+    def _get_redundant_distance_mapping(self):
         """Reformulates pairwise distances from shape [n_examples, n_dist]
         to shape [n_examples, n_beads, n_neighbors]
 


### PR DESCRIPTION
The main thing I did here is make `order` an attribute of `ProteinBackboneStatistics` (also renamed previous attribute `_order` to avoid confusion). The `order` is determined automatically based on what you calculate. I also removed `order` as an argument from `get_zscores` and `get_bond_constants`, so you have to stick with the order you started with when you instantiated the class.

The inspiration for doing this was that in your tests you rely on the ordering of keys in a dictionary, which is not a safe thing to do.

What do you think?