### PR TITLE
Activation function in last filter layer in Schnet

### DIFF
--- a/cgnet/feature/feature.py
+++ b/cgnet/feature/feature.py
@@ -184,8 +184,8 @@ class ContinuousFilterConvolution(nn.Module):
         super(ContinuousFilterConvolution, self).__init__()
         filter_layers = LinearLayer(num_gaussians, num_filters, bias=True,
                                     activation=ShiftedSoftplus())
-        # No activation function here allows the filter generator to contain
-        # negative values.
+        # No activation function in the last layer allows the filter generator
+        # to contain negative values.
         filter_layers += LinearLayer(num_filters, num_filters, bias=True)
         self.filter_generator = nn.Sequential(*filter_layers)
 


### PR DESCRIPTION

 Development:
 - [x] Implement feature / fix bug
 - [ ] Add documentation
 - [ ] Add tests
 
 Checks:
 - [x] Run `nosetests`
 - [x] Check pep8 compliance

Hey!

Some weeks ago I asked in the Schnetpack repository why there was no activation function in the last layer of the filter ([here](https://github.com/atomistic-machine-learning/schnetpack/issues/131)).
Removing the activation function allows the filter to have negative values. Doesn't seem to have that much of an impact, but I wanted to be consistent and to clarify since I left the comment there in the code.
If you have any strong opinions let me know, just wanted to clarify this (also for myself)
