### PR TITLE
Suggestion for the Schnetblock and future integration of Schnet

### DIFF
--- a/cgnet/feature/feature.py
+++ b/cgnet/feature/feature.py
@@ -380,21 +380,27 @@ class SchnetBlock(nn.Module):
                  variance=1.0,
                  n_interaction_blocks=1,
                  share_weights=True):
-        """Initialization
+        """
 
         Parameters
         ----------
-        interaction_block : InteractionBlock
-            single schnet InteractionBlock, containing a
-            ContinuousFilterConvolution and surrounding LinearLayers
-        rbf_layer : RadialBasisFunction
-            radial basis function layer that provides feature expansion into
-            gaussian basis prior to elementwise multiplication with a
-            ContinuousFilterConvolution
-        residual_connect : bool (default=True)
-            specifies whether or not to additively combine the input and output
-            features of the interaction block through a residual connection
-
+        feature_size: int
+            Input size and number of filters for the InteractionBlock.
+            Needs to be clarified a bit better here.
+        embedding_layer: torch.nn.Module
+            Class that embeds a property into a feature vector.
+        geometry_calculator: something that lets us compute distances and neighbors
+        rbf_cutoff: float
+            Cutoff for the radial basis function.
+        num_gaussians: int
+            Number of gaussians for the gaussian expansion in the radial basis
+            function.
+        variance: float
+            The variance (standard deviation squared) of the Gaussian functions.
+        n_interaction_blocks: int
+            Number of interaction blocks.
+        share_weights: bool
+            If True, shares the weights between all interaction blocks.
         """
         super(SchnetBlock, self).__init__()
         self.embedding = embedding_layer
@@ -403,11 +409,13 @@ class SchnetBlock(nn.Module):
                                              num_gaussians=num_gaussians,
                                              variance=variance)
         if share_weights:
+            # Lets the interaction blocks share the weights
             self.interaction_blocks = nn.ModuleList(
                 [InteractionBlock(feature_size, num_gaussians, feature_size)]
                 * n_interaction_blocks
             )
         else:
+            # Every interaction block has their own weights
             self.interaction_blocks = nn.ModuleList(
                 [InteractionBlock(feature_size, num_gaussians, feature_size)
                  for _ in range(n_interaction_blocks)]
@@ -435,6 +443,7 @@ class SchnetBlock(nn.Module):
 
         """
         # TODO DOM: need to check out the new geometry stuff to do this step properly
+        # but you get the idea
         distances = self.geometry.compute_distances(coordinates)
         neighbors = self.geometry.compute_neighbors(coordinates)
 


### PR DESCRIPTION
 Development:
 - [x] Implement feature / fix bug
 - [ ] Add documentation
 - [ ] Add tests
 
 Checks:
 - [ ] Run `nosetests`
 - [ ] Check pep8 compliance

Hey @coarse-graining/developers 

based on #78 I made some suggestions on how to proceed with the SchNetBlock so that we can integrate it without "much" trouble into our existing CGNet class.

I think Schnet should work the same way as the existing `GeometryFeature` works, meaning that we can pass it like this:

```
ala2_net = CGnet(arch=layers, 
                         criterion=ForceLoss(),
                         feature=schnet_layer,
                         priors=priors)
```
The only issue with this is that in the forward pass of `CGnet`, because ,besides coordinates, Schnet requires another input for the embedding layer. In Schnet it was the nuclear charge, but as we discussed we might experiment here. But aside from that, Schnet returns a feature vector as usual that needs to be passed through some linear layers (`arch` argument in CGnet). So in theory I don't see any big problems here.

What are your opinions about this?
Shall we have an optional argument in the forward pass or do you have another idea? I think
it's crucial and we should decide together.

Some of the code, especially for the distances/neighbors/Geometry, is a bit pseudo, but I hope you get the idea on how I envisioned everything.

Major changes in Schnetblock are:
* Tools/Layers get initialized inside the class instead of being arguments
* Multiple interaction blocks can be stacked
* Neighborlists would be calculated during the forward pass

I also  included an example on a simple embedding layer similar to the one that is used in schnet.
