### PR TITLE
converted simulation loop to full torch

### DIFF
--- a/cgnet/network/utils.py
+++ b/cgnet/network/utils.py
@@ -320,13 +320,13 @@ class Simulation():
 
         if self.verbose:
             print('100% finished.')
-        self.simulated_traj = self.swap_axes(self.simulated_traj,0,1).numpy()
+        self.simulated_traj = self.swap_axes(self.simulated_traj,0,1).cpu().numpy()
 
         if self.save_forces:
             self.simulated_forces = self.swap_axes(self.simulated_forces,
-                                                   0, 1).numpy()
+                                                   0, 1).cpu().numpy()
 
         if self.save_potential:
             self.simulated_potential = self.swap_axes(self.simulated_potential,
-                                                      0, 1).numpy()
+                                                      0, 1).cpu().numpy()
         return self.simulated_traj


### PR DESCRIPTION
 Development:
 - [x] Implement feature / fix bug
 - [ ] Add documentation
 - [ ] Add tests
 
 Checks:
 - [x] Run `nosetests`
 - [x] Check pep8 compliance

Hey guys. I converted the inner simulation loop so that there are no longer any calls to `.numpy()` (though we must still call `.detach()` to prevent the computational graph from being dragged along). I also added `torch.device` functionality so that GPU can be utilized for simulation. I ran the example notebook and nosetests to double check that externally nothing is changed. Let me know what you think.
