### PR TITLE
Feature fix

### DIFF
--- a/cgnet/feature/combiner.py
+++ b/cgnet/feature/combiner.py
@@ -76,6 +76,10 @@ class FeatureCombiner(nn.Module):
     (3) corresponds to classic pairwise distance-based SchNet. In this case,
     the SchnetFeature must be initialized with calculate_geometry=True
     so that it can use Geometry() tools to calculate distances on the fly.
+    If calculate_geometry=False, the input to the network must be pairwise
+    distances of size [n_frames, n_beads, n_neighbors], and the terminal
+    CGnet autograd function will compute derivates with respect to pairwise
+    distances instead of cartesian coordinates.
 
 
     References


### PR DESCRIPTION
 Development:
 - [x] Implement feature / fix bug
 - [x] Add documentation
 - [ ] Add tests
 
 Checks:
 - [x] Run `nosetests`
 - [x] Check pep8 compliance

Hey guys. Following the discussion in #98, I have added an additional warning about using `SchnetFeature` without a preceding `GeometryFeature`, and I have also added an additional note in the class documentation about the different use cases of combining `SchnetFeature` and `GeometryFeature`. Let me know what you guys think, and if there is anything to add/change.
