### PR TITLE
fixed GeometryStatistics instancing bug in test_gpu.py

### DIFF
--- a/cgnet/tests/test_gpu.py
+++ b/cgnet/tests/test_gpu.py
@@ -26,7 +26,9 @@ def generate_model():
     coords = np.random.randn(n_frames, n_beads, 3).astype('float32')
 
     # Next, we gather the statistics for Bond/Repulsion priors
-    stats = GeometryStatistics(coords)
+    stats = GeometryStatistics(coords, backbone_inds='all',
+                               get_all_distances=True, get_backbone_angles=True,
+                               get_backbone_dihedrals=True)
 
     bonds_list, _ = stats.get_prior_statistics('Bonds', as_list=True)
     bonds_idx = stats.return_indices('Bonds')


### PR DESCRIPTION
 Development:
 - [x] Implement feature / fix bug
 - [ ] Add documentation
 - [ ] Add tests
 
 Checks:
 - [x] Run `nosetests`
 - [x] Check pep8 compliance

There was a bug in `generate_model()` in `test_gpu.py`, which was throwing an error during the instancing of the `GeometryStatistics` object because the features were not specified. This change in the default features for `GeometryStatistics` was changed recently with the merging of SchNet utilities to the master branch, but we likely never encountered this bug because it requires a local GPU. Hence, it was encountered when I ran `nosetests -v` on a GPU-armed machined. I set all backbone feature kwargs to `True` and now the all tests (including the GPU ones) run fine. Let me know if you see anything else that needs to be changed.
