### PR TITLE
Fixed lipschitz_projection when different cuda device is specified 

### DIFF
--- a/cgnet/network/utils.py
+++ b/cgnet/network/utils.py
@@ -64,8 +64,9 @@ def lipschitz_projection(model, strength=10.0, mask=None):
             weight = layer.weight.data
             u, s, v = torch.svd(weight)
             if next(model.parameters()).is_cuda:
+                device = weight.device
                 lip_reg = torch.max(((s[0]) / strength),
-                                    torch.tensor([1.0]).cuda())
+                                    torch.tensor([1.0]).to(device))
             else:
                 lip_reg = torch.max(((s[0]) / strength),
                                     torch.tensor([1.0]))


### PR DESCRIPTION

 Development:
 - [x] Implement feature / fix bug
 - [ ] Add documentation
 - [ ] Add tests
 
 Checks:
 - [ ] Run `nosetests`
 - [ ] Check pep8 compliance

Hey,

the `lipschitz_projection` was failing when a different cuda device is specified (like `torch.device('cuda:1')`).
This fix transfers the `lip_reg` tensor always to the correct device.

Please test if it works for you! 
This should not interfere with our existing code due to the `device` being inferred from the weights tensor directly. So no new arguments need to be passed.