### PR TITLE
Nan prior fix

### DIFF
--- a/cgnet/feature/geometry.py
+++ b/cgnet/feature/geometry.py
@@ -38,7 +38,24 @@ class Geometry():
             self.bool = np.bool
             self.float32 = np.float32
 
+    def check_for_nans(self, object, name=None):
+        """This method checks an object for the presence of nans and
+        returns an error if any nans are found.
+        """
+        if name is None:
+            name = ''
+
+        if self.isnan(object).any():
+            raise ValueError(
+                "Nan found in {}. Check your coordinates!)".format(
+                    name)
+            )
+
     def check_array_vs_tensor(self, object, name=None):
+        """This method checks whether the object (i.e., numpy array or torch
+        tensor) is consistent with the method chosen for the Geometry
+        instance (i.e., 'numpy' or 'torch', respectively).
+        """
         if name is None:
             name = ''
 
@@ -117,14 +134,20 @@ class Geometry():
         self.check_array_vs_tensor(data, 'data')
 
         distances = self.get_vectorize_inputs(distance_inds, data)
+
         if norm:
             distances = self.norm(distances, axis=2)
-        assert not self.isnan(distances), \
-            'NaN found during distance calculation. Check your coordinates!'
+
+        self.check_for_nans(distances, 'distances')
+
         return distances
 
-    def get_angles(self, angle_inds, data):
+    def get_angles(self, angle_inds, data, clip=True):
         """Calculates angles in a vectorized fashion.
+
+        If clip is True (default), then the angle cosines are clipped
+        to be between -1 and 1 to account for numerical error.
+
         """
         self.check_array_vs_tensor(data, 'data')
 
@@ -138,16 +161,18 @@ class Geometry():
         # formulation.
         base *= -1
 
-        interval = self.sum(base * offset, axis=2) / self.norm(base,
+        angles = self.sum(base * offset, axis=2) / self.norm(base,
                                                                axis=2) / self.norm(
             offset, axis=2)
 
-        # Clipping to prevent the arccos to be NaN
-        angles = self.arccos(self.clip(interval,
-                                       lower_bound=-1.,
-                                       upper_bound=1.))
-        assert not self.isnan(angles), \
-            'NaN found during angle calculation. Check your coordinates!'
+        if clip:
+            # Clipping to prevent the arccos to be NaN
+            angles = self.arccos(self.clip(angles,
+                                           lower_bound=-1.,
+                                           upper_bound=1.))
+
+        self.check_for_nans(angles, 'angles')
+
         return angles
 
     def get_dihedrals(self, dihed_inds, data):
@@ -181,10 +206,9 @@ class Geometry():
                                   axis=2)/self.norm(
             cp_base[:, ::2], axis=2)/self.norm(plane_vector[:, ::2], axis=2)
 
-        assert not self.isnan(dihedral_cosines), \
-            'NaN found during dihedral calculation. Check your coordinates!'
-        assert not self.isnan(dihedral_sines), \
-            'NaN found during dihedral calculation. Check your coordinates!'
+
+        self.check_for_nans(dihedral_cosines, 'dihedral cosines')
+        self.check_for_nans(dihedral_sines, 'dihedral sines')
 
         return dihedral_cosines, dihedral_sines
 
@@ -250,6 +274,10 @@ class Geometry():
     # # # # # # # # # # # # # # Versatile Methods # # # # # # # # # # # # # #
     # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
+    # The methods implemented below should modify the originals as little as
+    # possible, such that the documentation for the respective method on the
+    # numpy and pytorch websites should be sufficient.
+
     # Methods defined: arccos, cross, norm, sum, arange, tile, eye, ones,
     #                  to_type, clip, isnan
 
@@ -312,14 +340,14 @@ class Geometry():
         elif self.method == 'numpy':
             return x.astype(dtype)
 
-    def clip(self, x, lower_bound, upper_bound):
+    def clip(self, x, lower_bound, upper_bound, out=None):
         if self.method == 'torch':
-            return torch.clamp(x, min=lower_bound, max=upper_bound)
+            return torch.clamp(x, min=lower_bound, max=upper_bound, out=out)
         elif self.method == 'numpy':
-            return np.clip(x, a_min=lower_bound, a_max=upper_bound)
+            return np.clip(x, a_min=lower_bound, a_max=upper_bound, out=out)
 
     def isnan(self, x):
         if self.method == 'torch':
-            return torch.isnan(x).any()
+            return torch.isnan(x)
         elif self.method == 'numpy':
-            return np.isnan(x).any()
+            return np.isnan(x)

--- a/cgnet/network/priors.py
+++ b/cgnet/network/priors.py
@@ -67,7 +67,8 @@ class _PriorLayer(nn.Module):
         super(_PriorLayer, self).__init__()
         if len(callback_indices) != len(interaction_parameters):
             raise ValueError(
-                "callback_indices and interaction parameters must have the same length")
+                "callback_indices and interaction_parameters must have the same length"
+                )
         self.interaction_parameters = interaction_parameters
         self.callback_indices = callback_indices
 
@@ -221,20 +222,24 @@ class HarmonicLayer(_PriorLayer):
             callback_indices, interaction_parameters)
         for param_dict in self.interaction_parameters:
             if (key in param_dict for key in ('k', 'mean')):
-                assert not torch.isnan(param_dict['k']).any(), \
+                if torch.isnan(param_dict['k']).any():
+                    raise ValueError(
                     'Harmonic spring constant "k" contains NaNs.' \
                     'Check your parameters.'
-                assert not torch.isnan(param_dict['mean']).any(),  \
+                        )
+                if torch.isnan(param_dict['mean']).any():
+                    raise ValueError(
                     'Center of the harmonic interaction "mean" contains NaNs.'\
                     'Check your parameters.'
-                pass
+                        )
             else:
                 KeyError('Missing or incorrect key for harmonic parameters')
         harmonic_parameters = torch.tensor([])
         for param_dict in self.interaction_parameters:
             harmonic_parameters = torch.cat((harmonic_parameters,
                                              torch.tensor([[param_dict['k']],
-                                                           [param_dict['mean']]])), dim=1)
+                                                           [param_dict['mean']]])),
+                                                           dim=1)
         self.register_buffer('harmonic_parameters', harmonic_parameters)
 
     def forward(self, in_feat):

--- a/cgnet/tests/test_geometry_core.py
+++ b/cgnet/tests/test_geometry_core.py
@@ -101,19 +101,19 @@ def test_nan_check():
     torch_nan_coords = torch.from_numpy(nan_coords)
 
     # Check if an assert is raised
-    np.testing.assert_raises(AssertionError,
+    np.testing.assert_raises(ValueError,
                              g_numpy.get_distances, _distance_pairs, nan_coords)
-    np.testing.assert_raises(AssertionError,
+    np.testing.assert_raises(ValueError,
                              g_numpy.get_angles, angle_pairs, nan_coords)
-    np.testing.assert_raises(AssertionError,
+    np.testing.assert_raises(ValueError,
                              g_numpy.get_dihedrals, dihedral_pairs, nan_coords)
 
-    np.testing.assert_raises(AssertionError,
+    np.testing.assert_raises(ValueError,
                              g_torch.get_distances, _distance_pairs,
                              torch_nan_coords)
-    np.testing.assert_raises(AssertionError,
+    np.testing.assert_raises(ValueError,
                              g_torch.get_angles, angle_pairs,
                              torch_nan_coords)
-    np.testing.assert_raises(AssertionError,
+    np.testing.assert_raises(ValueError,
                              g_torch.get_dihedrals, dihedral_pairs,
                              torch_nan_coords)

--- a/cgnet/tests/test_nnet.py
+++ b/cgnet/tests/test_nnet.py
@@ -197,7 +197,7 @@ def test_harmonic_nan_check():
     bonds_interactions[random_idx]['mean'] = torch.Tensor([np.nan])
 
     # Check if an assert is raised
-    np.testing.assert_raises(AssertionError,
+    np.testing.assert_raises(ValueError,
                              HarmonicLayer, bonds_idx, bonds_interactions)
 
 


### PR DESCRIPTION
 Development:
 - [x] Implement feature / fix bug
 - [ ] Add documentation
 - [x] Add tests
 
 Checks:
 - [x] Run `nosetests`
 - [x] Check pep8 compliance

Hey, 
this week I ran into an issue in which an angle was `NaN` due to the `arccos` getting a value that was `1.00001`. It took a while to debug because the issue became apparent much later during the Lipschitz calculation due to the weights being `NaN`. So it basically went through `Geometry`, `GeometryStatistics`, `HarmonicLayer` and a `.forward()` without being caught. Therefore, I thought some safety measures would be useful.

I added a clipping functionality that ensures that the values in the `arccos` are always between -1 and 1. In case something else goes wrong, I added `assert` in the distance, angle and dihedral calculation and also in the initialization of the `HarmonicLayer`. There are two new tests to check if the asserts are working.

Let me know what you think and if this is too much safety :) 