### PR TITLE
Fixed bug in neighbor masking code

### DIFF
--- a/cgnet/feature/geometry.py
+++ b/cgnet/feature/geometry.py
@@ -227,7 +227,8 @@ class Geometry():
         Returns
         -------
         neighbors: torch.Tensor or np.array
-            Indices of all neighbors of each bead.
+            Indices of all neighbors of each bead. This is not affected by the
+            mask.
             Shape [n_frames, n_beads, n_neighbors]
         neighbor_mask: torch.Tensor or np.array
             Index mask to filter out non-existing neighbors that were
@@ -254,8 +255,6 @@ class Geometry():
         if cutoff is not None:
             # Create an index mask for neighbors that are inside the cutoff
             neighbor_mask = distances < cutoff
-            # Set the indices of beads outside the cutoff to 0
-            neighbors[~neighbor_mask] = 0
             neighbor_mask = self.to_type(neighbor_mask, self.float32)
         else:
             neighbor_mask = self.ones((n_frames, n_beads, n_neighbors),


### PR DESCRIPTION
 Development:
 - [x] Implement feature / fix bug
 
 Checks:
 - [x] Run `nosetests`

The neighbor masking procedure did two things: (1) it set the index of every masked neighbor to zero, and (2) it created a boolean mask of which neighbors to consider. (1) is actually never used in the code to enforce the masking; everything is calculated and then the masked stuff is hidden.

However, the neighbors were already zero-indexed. So this setting to zero in part (1) meant that a bunch of neighbors were becoming different beads.

I went through and tested the equivalence of this current change (not setting masked neighbors to zero anymore) with the old code and everything seems to be fine. You can check out the branch `schnet-bug-fix` for that code if you want to do any of your own testing, which adds an option `set_to_zero` for various functions.

Let me know what you think.
