### PR TITLE
axis to dim change in torch.sum

### DIFF
--- a/cgnet/network/simulation.py
+++ b/cgnet/network/simulation.py
@@ -535,7 +535,7 @@ class Simulation():
 
         if v_new is not None:
             kes = 0.5 * torch.sum(torch.sum(self.masses[:, None]*v_new**2,
-                                            axis=2), axis=1)
+                                            dim=2), dim=1)
             self.kinetic_energies[save_ind, :] = kes
 
     def _log_progress(self, iter_):


### PR DESCRIPTION
 Development:
 - [x] Implement feature / fix bug

While this doesn't affect the pytorch >= 1.2 functionality, it's useful for anyone manually porting to pytorch <= 1.1, and also maintains consistency with the use of `dim` in `feature/geometry.py`. This change isn't needed in the actual `pytorch-1.1` branch, which has an earlier version of the simulation utilities. 