### PR TITLE
Repulsion prefactor fix

### DIFF
--- a/cgnet/network/priors.py
+++ b/cgnet/network/priors.py
@@ -187,7 +187,7 @@ class RepulsionLayer(_PriorLayer):
         n = len(in_feat)
         energy = torch.sum((self.repulsion_parameters[0, :]/in_feat)
                            ** self.repulsion_parameters[1, :],
-                           1).reshape(n, 1) / 2
+                           1).reshape(n, 1)
         return energy
 
 

--- a/cgnet/tests/test_nnet.py
+++ b/cgnet/tests/test_nnet.py
@@ -138,7 +138,7 @@ def test_repulsion_layer():
     p1 = torch.tensor(ex_vols).double()
     p2 = torch.tensor(exps).double()
     energy_check = torch.sum((p1/output_features[:, repul_idx]) ** p2,
-                             1).reshape(len(output_features), 1) / 2
+                             1).reshape(len(output_features), 1)
     np.testing.assert_array_equal(energy.detach().numpy(),
                                   energy_check.detach().numpy())
 


### PR DESCRIPTION
 Development:
 - [x] Implement feature / fix bug
 - [ ] Add documentation
 - [ ] Add tests
 
 Checks:
 - [x] Run `nosetests`
 - [x] Check pep8 compliance

Hello. This is a fix for the issue about the outer repulsion factor described in #199 . The original outer factor of 1/2 has been removed in order to be consistent with the literature. Please let me know if there is anything else that can be changed and/or improved.
