### PR TITLE
variance warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ python setup.py install
 Notes
 -----
 For compatibility with `pytorch==1.1`, please use the `pytorch-1.1` branch. This branch currently does not include the updates for variable size and Langevin dynamics, nor some normalization options.
+```diff
+- CGnet models can display high variance between different training runs. For more stable models, we recommend using CGSchNet instead.
+```
 
 Cite
 ----


### PR DESCRIPTION
 Development:
 - [ ] Implement feature / fix bug
 - [x] Add documentation
 - [ ] Add tests
 
 Checks:
 - [ ] Run `nosetests`
 - [ ] Check pep8 compliance

Hello. This PR adds a warning about CGnet model variance, which can be high among several different training runs. It offers a suggestion to use CGSchNet instead, which seems to be more stable. Let me know if there is anything else to change or improve.
